### PR TITLE
Rename display name to OpenFieldService

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<img src="readme-banner.png" alt="Open Field Service preview" width="100%" />
+<img src="readme-banner.png" alt="OpenFieldService preview" width="100%" />
 
-# Open Field Scheduling: The Open-Source PestPac & ServiceTitan Alternative
+# OpenFieldService: The Open-Source PestPac & ServiceTitan Alternative
 
 [![Deploy with Clawnify](https://app.clawnify.com/deploy-button.svg)](https://app.clawnify.com/deploy?repo=clawnify/open-fieldservice)
 
@@ -10,13 +10,13 @@ Built with **Preact + Hono + SQLite**. Ships with a clean dashboard UI, weekly c
 
 ## What Is It?
 
-Open Field Scheduling is a production-ready field service management platform designed for the OpenClaw community. Think of it as an open-source alternative to **PestPac**, **ServiceTitan**, **FieldWork**, **Jobber**, or **Housecall Pro** — a complete scheduling and dispatch system you can self-host, customize, and embed in any SaaS product.
+OpenFieldService is a production-ready field service management platform designed for the OpenClaw community. Think of it as an open-source alternative to **PestPac**, **ServiceTitan**, **FieldWork**, **Jobber**, or **Housecall Pro** — a complete scheduling and dispatch system you can self-host, customize, and embed in any SaaS product.
 
 Unlike PestPac or ServiceTitan, this runs entirely on your own infrastructure. No per-user fees, no contracts, no vendor lock-in. Manage your entire field service operation from scheduling to invoicing.
 
 ## Built for Every Field Service Vertical
 
-Open Field Scheduling is **vertical-agnostic** — configure service types, pricing, and workflows for any industry:
+OpenFieldService is **vertical-agnostic** — configure service types, pricing, and workflows for any industry:
 
 | Industry | Example Services |
 |----------|-----------------|

--- a/agent.md
+++ b/agent.md
@@ -1,4 +1,4 @@
-# Field Service Scheduler
+# OpenFieldService
 
 A scheduling and dispatch app for field service businesses — pest control, HVAC, plumbing, cleaning, landscaping, and more.
 

--- a/clawnify.json
+++ b/clawnify.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://app.clawnify.com/schema/v1/clawnify.json",
   "version": 1,
-  "name": "Field Service Scheduler",
+  "name": "OpenFieldService",
   "description": "Field service scheduling and business management with customers, technicians, service types, and job tracking. Like PestPac, FieldWork, or ServiceTitan. Best for pest control, HVAC, plumbing, cleaning, landscaping, or any field service business that needs appointment scheduling, technician dispatch, recurring jobs, and service history.",
   "icon": "icon.svg",
   "screenshot": "https://github.com/user-attachments/assets/f200eed4-ac02-49fc-9898-a46d209dc432",
@@ -14,7 +14,7 @@
   },
 
   "deploy": {
-    "title": "Deploy your Field Service Scheduler",
+    "title": "Deploy your OpenFieldService",
     "subtitle": "Like PestPac or ServiceTitan — customized for your business in minutes",
     "prompts": [
       {

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Field Service Scheduler</title>
+  <title>OpenFieldService</title>
   <meta name="description" content="Open-source field service scheduling and business management software">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="Scheduler">

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Field Service Scheduler",
+  "name": "OpenFieldService",
   "description": "Field service scheduling and business management with customers, technicians, service types, and job tracking. Like PestPac, FieldWork, or ServiceTitan. Best for pest control, HVAC, plumbing, cleaning, landscaping, or any field service business that needs appointment scheduling, technician dispatch, recurring jobs, and service history.",
   "framework": "preact+hono",
   "files": [

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,7 +4,7 @@ import { query, get, run } from "./db.js";
 type Env = { Bindings: { DB: D1Database } };
 
 const app = createApp<Env>({
-  title: "Field Service Scheduler",
+  title: "OpenFieldService",
   version: "1.0.0",
   description:
     "Field service scheduling and business management with customers, technicians, service types, and job tracking.",


### PR DESCRIPTION
Collapses the spaced product name into the single-word `OpenX` form, matching the OpenCut convention.

Display surfaces only: README, `clawnify.json` name, agent guide, app/API titles, `manifest.json`, UI strings.

Unchanged: repo slug, package name, app slug, D1 database names.