### PR TITLE
Seed sample data and counters from the app, not schema.sql

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -10,6 +10,81 @@ const app = createApp<Env>({
     "Field service scheduling and business management with customers, technicians, service types, and job tracking.",
 });
 
+app.use("*", async (_c, next) => {
+  await ensureSeeded();
+  await next();
+});
+
+// ── First-run data ─────────────────────────────────────────────────
+// A deploy applies `schema.sql` as DDL only — a seed INSERT there fails the
+// whole build — so the counters and the example rows are written here, once,
+// while their tables are still empty. A re-deploy never resurrects a row the
+// user deleted, because the table is no longer empty.
+
+const META_DEFAULTS: Array<[string, string]> = [
+  ["job_counter", "0"],
+  ["identifier_prefix", "JOB"],
+  ["invoice_counter", "0"],
+  ["invoice_prefix", "INV"],
+];
+
+/** id, name, description, default_duration, default_price, color */
+const DEMO_SERVICE_TYPES: Array<[number, string, string, number, number, string]> = [
+  [1, "Standard Service", "Standard service visit", 60, 150, "#16a34a"],
+  [2, "Inspection", "On-site inspection and assessment", 45, 75, "#0891b2"],
+  [3, "Emergency", "Urgent same-day service call", 90, 300, "#dc2626"],
+  [4, "Follow-up", "Follow-up visit after initial service", 30, 50, "#9333ea"],
+  [5, "Installation", "Equipment or system installation", 120, 400, "#ea580c"],
+  [6, "Maintenance", "Routine maintenance visit", 60, 125, "#ca8a04"],
+];
+
+/** id, name, unit, unit_cost, in_stock */
+const DEMO_MATERIALS: Array<[number, string, string, number, number]> = [
+  [1, "Service Fee", "ea", 0, 999],
+  [2, "Filter Replacement", "ea", 25, 50],
+  [3, "Sealant", "tube", 12, 30],
+  [4, "Travel Surcharge", "ea", 35, 999],
+  [5, "Disposable Supplies", "kit", 8, 100],
+];
+
+let seeded = false; // per-isolate fast path; the COUNT re-checks are cheap
+
+async function ensureSeeded(): Promise<void> {
+  if (seeded) return;
+  seeded = true;
+  try {
+    // Load-bearing, not sample data: the job and invoice numbering depends on
+    // these rows existing, so they are restored even on a populated database.
+    for (const [key, value] of META_DEFAULTS) {
+      await run("INSERT OR IGNORE INTO _meta (key, value) VALUES (?, ?)", [key, value]);
+    }
+
+    const serviceTypes = await get<{ n: number }>("SELECT COUNT(*) AS n FROM service_types");
+    if ((serviceTypes?.n ?? 0) === 0) {
+      for (const st of DEMO_SERVICE_TYPES) {
+        await run(
+          "INSERT OR IGNORE INTO service_types (id, name, description, default_duration, default_price, color) VALUES (?, ?, ?, ?, ?, ?)",
+          st,
+        );
+      }
+    }
+
+    const materials = await get<{ n: number }>("SELECT COUNT(*) AS n FROM materials");
+    if ((materials?.n ?? 0) === 0) {
+      for (const m of DEMO_MATERIALS) {
+        await run(
+          "INSERT OR IGNORE INTO materials (id, name, unit, unit_cost, in_stock) VALUES (?, ?, ?, ?, ?)",
+          m,
+        );
+      }
+    }
+  } catch {
+    // A cold database mid-migration, or a table this build has not created
+    // yet: the next request retries. Never fail a request over sample data.
+    seeded = false;
+  }
+}
+
 // ── Shared Schemas ─────────────────────────────────────────────────
 
 const ErrorSchema = z.object({ error: z.string() }).openapi("Error");
@@ -95,7 +170,10 @@ async function nextIdentifier(): Promise<string> {
   const prefix = await get<{ value: string }>("SELECT value FROM _meta WHERE key = 'identifier_prefix'");
   const counter = await get<{ value: string }>("SELECT value FROM _meta WHERE key = 'job_counter'");
   const next = parseInt(counter?.value || "0", 10) + 1;
-  await run("UPDATE _meta SET value = ? WHERE key = 'job_counter'", [String(next)]);
+  await run(
+    "INSERT INTO _meta (key, value) VALUES ('job_counter', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    [String(next)],
+  );
   return `${prefix?.value || "JOB"}-${next}`;
 }
 
@@ -103,7 +181,10 @@ async function nextInvoiceIdentifier(): Promise<string> {
   const prefix = await get<{ value: string }>("SELECT value FROM _meta WHERE key = 'invoice_prefix'");
   const counter = await get<{ value: string }>("SELECT value FROM _meta WHERE key = 'invoice_counter'");
   const next = parseInt(counter?.value || "0", 10) + 1;
-  await run("UPDATE _meta SET value = ? WHERE key = 'invoice_counter'", [String(next)]);
+  await run(
+    "INSERT INTO _meta (key, value) VALUES ('invoice_counter', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    [String(next)],
+  );
   return `${prefix?.value || "INV"}-${next}`;
 }
 

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -125,20 +125,12 @@ CREATE TABLE IF NOT EXISTS _meta (
   key TEXT PRIMARY KEY,
   value TEXT NOT NULL
 );
-INSERT OR IGNORE INTO _meta (key, value) VALUES ('job_counter', '0');
-INSERT OR IGNORE INTO _meta (key, value) VALUES ('identifier_prefix', 'JOB');
-INSERT OR IGNORE INTO _meta (key, value) VALUES ('invoice_counter', '0');
-INSERT OR IGNORE INTO _meta (key, value) VALUES ('invoice_prefix', 'INV');
+-- The counter and prefix rows are written by the app (ensureSeeded in
+-- src/server/index.ts): a deploy applies this file as DDL only, so a seed
+-- row here fails the whole build.
 
--- Example service types (users customize for their vertical)
-INSERT OR IGNORE INTO service_types (id, name, description, default_duration, default_price, color)
-VALUES
-  (1, 'Standard Service', 'Standard service visit', 60, 150, '#16a34a'),
-  (2, 'Inspection', 'On-site inspection and assessment', 45, 75, '#0891b2'),
-  (3, 'Emergency', 'Urgent same-day service call', 90, 300, '#dc2626'),
-  (4, 'Follow-up', 'Follow-up visit after initial service', 30, 50, '#9333ea'),
-  (5, 'Installation', 'Equipment or system installation', 120, 400, '#ea580c'),
-  (6, 'Maintenance', 'Routine maintenance visit', 60, 125, '#ca8a04');
+-- Example service types are seeded by the app on first request
+-- (ensureSeeded in src/server/index.ts), never here: DDL only.
 
 CREATE INDEX IF NOT EXISTS idx_jobs_customer ON jobs(customer_id);
 CREATE INDEX IF NOT EXISTS idx_jobs_technician ON jobs(technician_id);
@@ -154,11 +146,5 @@ CREATE INDEX IF NOT EXISTS idx_invoices_job ON invoices(job_id);
 CREATE INDEX IF NOT EXISTS idx_invoices_status ON invoices(status);
 CREATE INDEX IF NOT EXISTS idx_invoice_lines_invoice ON invoice_lines(invoice_id);
 
--- Example materials
-INSERT OR IGNORE INTO materials (id, name, unit, unit_cost, in_stock)
-VALUES
-  (1, 'Service Fee', 'ea', 0, 999),
-  (2, 'Filter Replacement', 'ea', 25, 50),
-  (3, 'Sealant', 'tube', 12, 30),
-  (4, 'Travel Surcharge', 'ea', 35, 999),
-  (5, 'Disposable Supplies', 'kit', 8, 100);
+-- Example materials are seeded by the app on first request
+-- (ensureSeeded in src/server/index.ts), never here: DDL only.


### PR DESCRIPTION
## The deploy failure this fixes

A Clawnify deploy applies `src/server/schema.sql` as **DDL only** — the platform's `parseSchemaObjects` throws (it refuses rather than skips) on any statement that is not `CREATE TABLE/INDEX/VIEW/TRIGGER` or `ALTER TABLE … ADD COLUMN`. One seed row therefore failed the entire build, for every user including the public Deploy button:

```
SCHEMA: unsupported statement in schema.sql — only CREATE TABLE/INDEX/VIEW/TRIGGER
and ALTER TABLE … ADD COLUMN are applied. Move seed data into the app.
Offending statement: INSERT OR IGNORE INTO _meta (key, value) VALUES ('job_counter', '0')
```

OpenFieldService could not deploy at all.

## What moved

Out of `src/server/schema.sql` (each replaced by a comment pointing at the app):

- the four `_meta` rows — `job_counter` `'0'`, `identifier_prefix` `'JOB'`, `invoice_counter` `'0'`, `invoice_prefix` `'INV'`
- `INSERT OR IGNORE INTO service_types …` — the six example service types
- `INSERT OR IGNORE INTO materials …` — the five example materials

Into `ensureSeeded()` in `src/server/index.ts`, run from an `app.use("*")` middleware registered right after `createApp()` (which already installs the `initDB(c.env)` middleware, so the DB is live by then). Values are byte-identical: same ids, names, descriptions, durations, prices, colors, units and ordering.

- module-level `let seeded = false` per-isolate fast path
- `service_types` and `materials` are seeded **only while still empty** (`SELECT COUNT(*)`), so a re-deploy never resurrects a row the user deleted
- the four `_meta` rows use `INSERT OR IGNORE` — they are load-bearing, not sample data, so they are restored even on a populated database
- the whole body is wrapped in `try { … } catch { seeded = false; }`: sample data can never fail a request, and the next request retries

No `CREATE` statement was touched.

## The counter write is now an upsert

`nextIdentifier()` and `nextInvoiceIdentifier()` wrote with:

```sql
UPDATE _meta SET value = ? WHERE key = 'job_counter'
```

That matches **zero rows** when the row is missing — which is exactly the state the seed move creates on a database whose first request has not run yet, or whose row was deleted. The counter would silently never advance, so every job would be handed the same identifier and the second insert would blow up on the `UNIQUE` constraint on `jobs.identifier` (same for `invoices.identifier`). Both writes are now:

```sql
INSERT INTO _meta (key, value) VALUES ('job_counter', ?)
ON CONFLICT(key) DO UPDATE SET value = excluded.value
```

The reads already carried hard-coded fallbacks (`|| "0"`, `|| "JOB"`, `|| "INV"`) and keep them. Nothing else in the server or the client assumed a seeded row exists: the job form's service type is optional and nullable, and no code hard-codes a demo id.

## Verification

```
$ grep -nE "^\s*(INSERT|UPDATE|DELETE|DROP|PRAGMA|REPLACE)" src/server/schema.sql
(no output)

$ pnpm install --frozen-lockfile --ignore-scripts
Done in 2s using pnpm v11.10.0

$ ./node_modules/.bin/vite build
✓ 1730 modules transformed.
dist/index.html                  0.85 kB │ gzip:  0.45 kB
dist/assets/index-EZ1CuZ2K.css  14.10 kB │ gzip:  3.08 kB
dist/assets/index-XPoUJLWu.js   83.47 kB │ gzip: 19.79 kB
✓ built in 844ms
```

`tsc --noEmit -p .` reports 16 errors — all of them pre-existing on `main` (missing `@cloudflare/workers-types` for `D1Database`, plus zod-openapi handler return-type variance). The error sets before and after this change are byte-identical, so this branch adds none. Left alone as out of scope.

Beyond the required checks, the SQL itself was exercised against a real SQLite database:

- `sqlite3 ofs.db < src/server/schema.sql` applies cleanly, and re-splitting the file the way the platform's parser does yields **24 statements, 0 non-CREATE**
- replaying `ensureSeeded()`'s statements produces the four `_meta` rows and the demo rows
- with the `job_counter` row deleted, the old `UPDATE` left it `<MISSING>`; the new upsert produced `1`, then `2`
